### PR TITLE
LIBILS-976. Fix statistics note configuration.

### DIFF
--- a/cloudapp/src/app/administration/administration.component.html
+++ b/cloudapp/src/app/administration/administration.component.html
@@ -27,8 +27,8 @@
                 <mat-option value="internal_note_1">Internal Note 1</mat-option>
                 <mat-option value="internal_note_2">Internal Note 2</mat-option>
                 <mat-option value="internal_note_3">Internal Note 3</mat-option>
-                <mat-option value="statistics_note_3">Statistics Note 1</mat-option>
-                <mat-option value="statistics_note_3">Statistics Note 2</mat-option>
+                <mat-option value="statistics_note_1">Statistics Note 1</mat-option>
+                <mat-option value="statistics_note_2">Statistics Note 2</mat-option>
                 <mat-option value="statistics_note_3">Statistics Note 3</mat-option>
                 <mat-option value="inventory_date">Inventory Date</mat-option>
             </mat-select>


### PR DESCRIPTION
Any value for the statistics notes would be saved as 3, but display as 1 in the configuration. This was due to a misconfigured dropdown.

https://umd-dit.atlassian.net/browse/LIBILS-976