### PR TITLE
Corrected logic errors.

### DIFF
--- a/cloudapp/src/app/results/results.component.html
+++ b/cloudapp/src/app/results/results.component.html
@@ -14,9 +14,13 @@
     <br>
     <h2>Problem Summary</h2>
     <span *ngIf="reportData.orderProblemLimit !== 'onlyOther'">
+        <p>Not In Alma: {{reportData.notInAlmaProblemCount}}</p>
+        <p>Unparsable Call Number: {{reportData.unparsableCallNumberProblemCount}}</p>
         <p>Order Issues: {{ reportData.orderProblemCount }}</p>
     </span>
     <span *ngIf="reportData.orderProblemLimit !== 'onlyOrder'">
+        <p>Not In Alma: {{reportData.notInAlmaProblemCount}}</p>
+        <p>Unparsable Call Number: {{reportData.unparsableCallNumberProblemCount}}</p>
         <p>Wrong Library: {{ reportData.libraryProblemCount }}</p>
         <p>Wrong Location: {{ reportData.locationProblemCount }}</p>
         <p>Policy Issue: {{ reportData.policyProblemCount }}</p>

--- a/cloudapp/src/app/services/dataProcessing/call-number.service.spec.ts
+++ b/cloudapp/src/app/services/dataProcessing/call-number.service.spec.ts
@@ -37,6 +37,7 @@ let getPhysicalItem = (callNum: string, description: string = null): ProcessedPh
         actualLocation: null,
         actualLocationInUnsortablesRemoved: null,
         correctLocation: null,
+        hasUnparsableCallNumberProblem: null,
         hasOrderProblem: null,
         hasTemporaryLocationProblem: null,
         hasLibraryProblem: null,


### PR DESCRIPTION
Corrected logic errors where 'not in alma' and 'unparsable call number' were not being shown when limiting the report to only other issues.

Additionally, corrected logic issue where scanning in was still active for reports that only were looking for order issues. This would cause scan in results to not display on the report and just shouldn't really happen in this mode.